### PR TITLE
feat: Partial Except

### DIFF
--- a/lib/inertia_rails/renderer.rb
+++ b/lib/inertia_rails/renderer.rb
@@ -72,7 +72,7 @@ module InertiaRails
     def computed_props
       _props = merge_props(shared_data, props).select do |key, prop|
         if rendering_partial_component?
-          key.in?(partial_keys) || prop.is_a?(AlwaysProp)
+          (key.in?(partial_keys) || prop.is_a?(AlwaysProp)) && !key.in?(partial_except_keys)
         else
           !prop.is_a?(IgnoreFirstLoadProp)
         end
@@ -129,6 +129,10 @@ module InertiaRails
 
     def partial_keys
       @partial_keys ||= (@request.headers['X-Inertia-Partial-Data'] || '').split(',').compact.map(&:to_sym)
+    end
+
+    def partial_except_keys
+      @partial_expected_keys ||= (@request.headers['X-Inertia-Partial-Except'] || '').split(',').compact.map(&:to_sym)
     end
 
     def reset_keys

--- a/spec/inertia/rendering_spec.rb
+++ b/spec/inertia/rendering_spec.rb
@@ -99,6 +99,25 @@ RSpec.describe 'rendering inertia views', type: :request do
     end
   end
 
+  context 'partial except rendering' do
+    let(:page) {
+      InertiaRails::Renderer.new('TestComponent', controller, request, response, '', props: { name: "Brandon", sport: 'hockey' }).send(:page)
+    }
+    let(:headers) {{
+      'X-Inertia' => true,
+      'X-Inertia-Partial-Data' => 'sport,name',
+      'X-Inertia-Partial-Except' => 'sport',
+      'X-Inertia-Partial-Component' => 'TestComponent',
+    }}
+
+    context 'with partial except header' do
+      before { get props_path, headers: headers }
+      it { is_expected.to eq page.to_json }
+      it { is_expected.to include('Brandon') }
+      it { is_expected.to_not include('hockey') }
+    end
+  end
+
   context 'lazy prop rendering' do
     context 'on first load' do
       let(:page) {


### PR DESCRIPTION
This PR introduces support for the `X-Inertia-Partial-Except` header to the Inertia Rails Renderer. This allows developers to exclude specific props from partial updates when using the Inertia.

Key Changes:

- Added logic to handle X-Inertia-Partial-Except within the computed_props method.
- Implemented new method partial_except_keys to retrieve the excluded props from the request headers and ensure these are omitted from partial updates.
- Updated the computed_props method to exclude props that are listed in X-Inertia-Partial-Except while still allowing props defined in X-Inertia-Partial-Data to be included in the partial update.
- Added unit test to validate that props listed in the X-Inertia-Partial-Except header are not included in the response.

Laravel implementation:
- https://github.com/inertiajs/inertia-laravel/blob/ddf47e999dcdabd2f370e5b9772a7449f4a81729/src/Response.php#L110