### PR TITLE
Add patch for validation error types on inertia:install

### DIFF
--- a/lib/generators/inertia/install/frameworks.yml
+++ b/lib/generators/inertia/install/frameworks.yml
@@ -16,6 +16,7 @@ react:
     "tsconfig.app.json": "tsconfig.app.json"
     "tsconfig.node.json": "tsconfig.node.json"
     "vite-env.d.ts": "%{js_destination_path}/vite-env.d.ts"
+    "inertia-rails.d.ts": "%{js_destination_path}/types/inertia-rails.d.ts"
   copy_files_js:
     "InertiaExample.jsx": "%{js_destination_path}/pages/InertiaExample.jsx"
   copy_files:
@@ -44,6 +45,7 @@ vue:
     "tsconfig.app.json": "tsconfig.app.json"
     "tsconfig.node.json": "tsconfig.node.json"
     "vite-env.d.ts": "%{js_destination_path}/vite-env.d.ts"
+    "inertia-rails.d.ts": "%{js_destination_path}/types/inertia-rails.d.ts"
   copy_files_js:
     "InertiaExample.vue": "%{js_destination_path}/pages/InertiaExample.vue"
 
@@ -64,6 +66,7 @@ svelte4:
     "tsconfig.json": "tsconfig.json"
     "tsconfig.node.json": "tsconfig.node.json"
     "vite-env.d.ts": "%{js_destination_path}/vite-env.d.ts"
+    "inertia-rails.d.ts": "%{js_destination_path}/types/inertia-rails.d.ts"
   copy_files_js:
     "InertiaExample.svelte": "%{js_destination_path}/pages/InertiaExample.svelte"
   copy_files:
@@ -89,6 +92,7 @@ svelte:
     "tsconfig.json": "tsconfig.json"
     "tsconfig.node.json": "tsconfig.node.json"
     "vite-env.d.ts": "%{js_destination_path}/vite-env.d.ts"
+    "inertia-rails.d.ts": "%{js_destination_path}/types/inertia-rails.d.ts"
   copy_files_js:
     "InertiaExample.svelte": "%{js_destination_path}/pages/InertiaExample.svelte"
   copy_files:

--- a/lib/generators/inertia/install/templates/react/inertia-rails.d.ts
+++ b/lib/generators/inertia/install/templates/react/inertia-rails.d.ts
@@ -1,0 +1,26 @@
+// See https://inertia-rails.dev/cookbook/handling-validation-error-types.md
+import type { FormDataConvertible, FormDataKeys } from '@inertiajs/core'
+import type { InertiaFormProps as OriginalProps } from '@inertiajs/react'
+
+type FormDataType = Record<string, FormDataConvertible>
+
+declare module '@inertiajs/react' {
+  interface InertiaFormProps<TForm extends FormDataType>
+    extends Omit<OriginalProps<TForm>, 'errors' | 'setError'> {
+    errors: Partial<Record<FormDataKeys<TForm>, string[]>>
+
+    setError(field: FormDataKeys<TForm>, value: string[]): void
+
+    setError(errors: Record<FormDataKeys<TForm>, string[]>): void
+  }
+
+  export { InertiaFormProps }
+
+  export function useForm<TForm extends FormDataType>(
+    initialValues?: TForm,
+  ): InertiaFormProps<TForm>
+  export function useForm<TForm extends FormDataType>(
+    rememberKey: string,
+    initialValues?: TForm,
+  ): InertiaFormProps<TForm>
+}

--- a/lib/generators/inertia/install/templates/svelte/inertia-rails.d.ts
+++ b/lib/generators/inertia/install/templates/svelte/inertia-rails.d.ts
@@ -1,0 +1,29 @@
+// See https://inertia-rails.dev/cookbook/handling-validation-error-types.md
+import type { FormDataConvertible, FormDataKeys } from '@inertiajs/core'
+import type { InertiaFormProps as OriginalProps } from '@inertiajs/svelte'
+import type { Writable } from 'svelte/store'
+
+type FormDataType = Record<string, FormDataConvertible>
+
+declare module '@inertiajs/svelte' {
+  interface InertiaFormProps<TForm extends FormDataType>
+    extends Omit<OriginalProps<TForm>, 'errors' | 'setError'> {
+    errors: Partial<Record<FormDataKeys<TForm>, string[]>>
+
+    setError(field: FormDataKeys<TForm>, value: string[]): this
+
+    setError(errors: Record<FormDataKeys<TForm>, string[]>): this
+  }
+
+  type InertiaForm<TForm extends FormDataType> = InertiaFormProps<TForm> & TForm
+
+  export { InertiaFormProps, InertiaForm }
+
+  export function useForm<TForm extends FormDataType>(
+    data: TForm | (() => TForm),
+  ): Writable<InertiaForm<TForm>>
+  export function useForm<TForm extends FormDataType>(
+    rememberKey: string,
+    data: TForm | (() => TForm),
+  ): Writable<InertiaForm<TForm>>
+}

--- a/lib/generators/inertia/install/templates/svelte4/inertia-rails.d.ts
+++ b/lib/generators/inertia/install/templates/svelte4/inertia-rails.d.ts
@@ -1,0 +1,29 @@
+// See https://inertia-rails.dev/cookbook/handling-validation-error-types.md
+import type { FormDataConvertible, FormDataKeys } from '@inertiajs/core'
+import type { InertiaFormProps as OriginalProps } from '@inertiajs/svelte'
+import type { Writable } from 'svelte/store'
+
+type FormDataType = Record<string, FormDataConvertible>
+
+declare module '@inertiajs/svelte' {
+  interface InertiaFormProps<TForm extends FormDataType>
+    extends Omit<OriginalProps<TForm>, 'errors' | 'setError'> {
+    errors: Partial<Record<FormDataKeys<TForm>, string[]>>
+
+    setError(field: FormDataKeys<TForm>, value: string[]): this
+
+    setError(errors: Record<FormDataKeys<TForm>, string[]>): this
+  }
+
+  type InertiaForm<TForm extends FormDataType> = InertiaFormProps<TForm> & TForm
+
+  export { InertiaFormProps, InertiaForm }
+
+  export function useForm<TForm extends FormDataType>(
+    data: TForm | (() => TForm),
+  ): Writable<InertiaForm<TForm>>
+  export function useForm<TForm extends FormDataType>(
+    rememberKey: string,
+    data: TForm | (() => TForm),
+  ): Writable<InertiaForm<TForm>>
+}

--- a/lib/generators/inertia/install/templates/vue/inertia-rails.d.ts
+++ b/lib/generators/inertia/install/templates/vue/inertia-rails.d.ts
@@ -1,0 +1,29 @@
+// See https://inertia-rails.dev/cookbook/handling-validation-error-types.md
+import type { FormDataConvertible, FormDataKeys } from '@inertiajs/core'
+import type { InertiaFormProps as OriginalProps } from '@inertiajs/vue3'
+
+type FormDataType = Record<string, FormDataConvertible>
+
+declare module '@inertiajs/vue3' {
+  interface InertiaFormProps<TForm extends FormDataType>
+    extends Omit<OriginalProps<TForm>, 'errors' | 'setError'> {
+    errors: Partial<Record<FormDataKeys<TForm>, string[]>>
+
+    setError(field: FormDataKeys<TForm>, value: string[]): this
+
+    setError(errors: Record<FormDataKeys<TForm>, string[]>): this
+  }
+
+  export type InertiaForm<TForm extends FormDataType> = TForm &
+    InertiaFormProps<TForm>
+
+  export { InertiaFormProps, InertiaForm }
+
+  export function useForm<TForm extends FormDataType>(
+    data: TForm | (() => TForm),
+  ): InertiaForm<TForm>
+  export function useForm<TForm extends FormDataType>(
+    rememberKey: string,
+    data: TForm | (() => TForm),
+  ): InertiaForm<TForm>
+}


### PR DESCRIPTION
WIP (need to try it out) https://github.com/inertiajs/inertia-rails/pull/215#issuecomment-2797236643

Also add to the tsconfig

---

In the docs' code examples and scaffolded code, the Rails' validation
errors object (array of strings) is passed as-is to Inertia's rederer.

To be consistent, the Typescript definitions should be patched.
